### PR TITLE
Wishlist Alert style, Wishlist, Code refactor

### DIFF
--- a/client/.eslintrc.cjs
+++ b/client/.eslintrc.cjs
@@ -12,6 +12,7 @@ module.exports = {
   settings: { react: { version: '18.2' } },
   plugins: ['react-refresh'],
   rules: {
+    'react/prop-types': 'off', // Disable prop-types rule
     'react/jsx-no-target-blank': 'off',
     'react-refresh/only-export-components': [
       'warn',

--- a/client/.eslintrc.cjs
+++ b/client/.eslintrc.cjs
@@ -13,6 +13,7 @@ module.exports = {
   plugins: ['react-refresh'],
   rules: {
     'react/prop-types': 'off', // Disable prop-types rule
+    'no-unused-vars' : 'off', // Disable no-unused-vars rule
     'react/jsx-no-target-blank': 'off',
     'react-refresh/only-export-components': [
       'warn',

--- a/client/src/components/Alerts/Cart/CartError.jsx
+++ b/client/src/components/Alerts/Cart/CartError.jsx
@@ -4,7 +4,7 @@ import { Alert, Box, Slide } from '@mui/material';
 //  'visible' prop - passed from parents to control alert visbility 
 const CartError = ({ visible }) => {
   const alert = (
-    <Alert severity='success' sx={{ width: '100%', mb: 2 }}>
+    <Alert severity='success' sx={{ maxWidth: '100%', mb: 2 }}>
         Error adding item to your cart.
     </Alert>
   );
@@ -12,9 +12,10 @@ const CartError = ({ visible }) => {
   return (
     <Box
       sx={{
-        width: '100%',
         position: 'fixed',
-        bottom: 1,
+        bottom: 0,
+        left: '50%', //  Positions the left edge of the Box at the center of the viewport
+        transform: 'translateX(-50%)', // Shifts Box left by 50% of its own width, centering it horizontally
         display: 'flex',
         justifyContent: 'center',
         alignItems: 'center',

--- a/client/src/components/Alerts/Cart/CartSuccess.jsx
+++ b/client/src/components/Alerts/Cart/CartSuccess.jsx
@@ -4,7 +4,7 @@ import { Alert, Box, Slide } from '@mui/material';
 //  'visible' prop - passed from parents to control alert visbility 
 const CartSuccess = ({ visible }) => {
   const alert = (
-    <Alert severity='success' sx={{ width: '100%', mb: 2 }}>
+    <Alert severity='success' sx={{ maxWidth: '100%', mb: 2 }}>
         Item added to Cart.
     </Alert>
   );
@@ -12,9 +12,10 @@ const CartSuccess = ({ visible }) => {
   return (
     <Box
       sx={{
-        width: '100%',
         position: 'fixed',
-        bottom: 1,
+        bottom: 0,
+        left: '50%', //  Positions the left edge of the Box at the center of the viewport
+        transform: 'translateX(-50%)', // Shifts Box left by 50% of its own width, centering it horizontally
         display: 'flex',
         justifyContent: 'center',
         alignItems: 'center',

--- a/client/src/components/Alerts/Cart/CartWarning.jsx
+++ b/client/src/components/Alerts/Cart/CartWarning.jsx
@@ -4,7 +4,7 @@ import { Alert, Box, Slide } from '@mui/material';
 //  'visible' prop - passed from parents to control alert visbility 
 const CartWarning = ({ visible }) => {
   const alert = (
-    <Alert severity='success' sx={{ width: '100%', mb: 2 }}>
+    <Alert severity='success' sx={{ maxWidth: '100%', mb: 2 }}>
         Sign in first.
     </Alert>
   );
@@ -12,9 +12,10 @@ const CartWarning = ({ visible }) => {
   return (
     <Box
       sx={{
-        width: '100%',
         position: 'fixed',
-        bottom: 1,
+        bottom: 0,
+        left: '50%', //  Positions the left edge of the Box at the center of the viewport
+        transform: 'translateX(-50%)', // Shifts Box left by 50% of its own width, centering it horizontally
         display: 'flex',
         justifyContent: 'center',
         alignItems: 'center',

--- a/client/src/components/Alerts/Wishlist/WishlistError.jsx
+++ b/client/src/components/Alerts/Wishlist/WishlistError.jsx
@@ -4,7 +4,7 @@ import { Alert, Box, Slide } from '@mui/material';
 //  'visible' prop - passed from parents to control alert visbility 
 const WishlistError = ({ visible }) => {
   const alert = (
-    <Alert severity='error' sx={{ width: '100%', mb: 2 }}>
+    <Alert severity='error' sx={{ maxWidth: '100%', mb: 2 }}>
         Error adding item to your wishlist.
     </Alert>
     );
@@ -12,9 +12,10 @@ const WishlistError = ({ visible }) => {
   return (
     <Box
       sx={{
-        width: '100%',
         position: 'fixed',
-        bottom: 1,
+        bottom: 0,
+        left: '50%', //  Positions the left edge of the Box at the center of the viewport
+        transform: 'translateX(-50%)', // Shifts Box left by 50% of its own width, centering it horizontally
         display: 'flex',
         justifyContent: 'center',
         alignItems: 'center',

--- a/client/src/components/Alerts/Wishlist/WishlistError.jsx
+++ b/client/src/components/Alerts/Wishlist/WishlistError.jsx
@@ -5,7 +5,7 @@ import { Alert, Box, Slide } from '@mui/material';
 const WishlistError = ({ visible }) => {
   const alert = (
     <Alert severity='error' sx={{ maxWidth: '100%', mb: 2 }}>
-        Error adding item to your wishlist.
+        Unable to add to wishlist.
     </Alert>
     );
 

--- a/client/src/components/Alerts/Wishlist/WishlistSuccess.jsx
+++ b/client/src/components/Alerts/Wishlist/WishlistSuccess.jsx
@@ -5,7 +5,7 @@ import { Alert, Box, Slide } from '@mui/material';
 const WishlistSuccess = ({ visible }) => {
   const alert = (
     <Alert severity='success' sx={{ maxWidth: '100%', mb: 2 }}>
-        Item added to wishlist.
+        Added to wishlist.
     </Alert>
   );
 

--- a/client/src/components/Alerts/Wishlist/WishlistSuccess.jsx
+++ b/client/src/components/Alerts/Wishlist/WishlistSuccess.jsx
@@ -4,7 +4,7 @@ import { Alert, Box, Slide } from '@mui/material';
 //  'visible' prop - passed from parents to control alert visbility 
 const WishlistSuccess = ({ visible }) => {
   const alert = (
-    <Alert severity='success' sx={{ width: '100%', mb: 2 }}>
+    <Alert severity='success' sx={{ maxWidth: '100%', mb: 2 }}>
         Item added to wishlist.
     </Alert>
   );
@@ -12,9 +12,10 @@ const WishlistSuccess = ({ visible }) => {
   return (
     <Box
       sx={{
-        width: '100%',
         position: 'fixed',
         bottom: 0,
+        left: '50%', //  Positions the left edge of the Box at the center of the viewport
+        transform: 'translateX(-50%)', // Shifts Box left by 50% of its own width, centering it horizontally
         display: 'flex',
         justifyContent: 'center',
         alignItems: 'center',

--- a/client/src/components/Alerts/Wishlist/WishlistWarning.jsx
+++ b/client/src/components/Alerts/Wishlist/WishlistWarning.jsx
@@ -4,7 +4,7 @@ import { Alert, Box, Slide } from '@mui/material';
 //  'visible' prop - passed from parents to control alert visbility 
 const WishlistWarning = ({ visible }) => {
   const alert = (
-    <Alert severity='warning' sx={{ width: '60%', mb: 2 }}>
+    <Alert severity='warning' sx={{ maxWidth: '100%', mb: 2 }}>
       Sign in first.
     </Alert>
   );
@@ -12,9 +12,10 @@ const WishlistWarning = ({ visible }) => {
   return (
     <Box
       sx={{
-        width: '100%',
         position: 'fixed',
         bottom: 0,
+        left: '50%', //  Positions the left edge of the Box at the center of the viewport
+        transform: 'translateX(-50%)', // Shifts Box left by 50% of its own width, centering it horizontally
         display: 'flex',
         justifyContent: 'center',
         alignItems: 'center',

--- a/client/src/hooks/Products/useWishlist.js
+++ b/client/src/hooks/Products/useWishlist.js
@@ -1,7 +1,6 @@
 import { useState } from 'react';
 import { useMutation } from '@apollo/client';
-import { add_wishlist } from '../../utils/mutations';
-import { delete_wishlist } from '../../utils/mutations';
+import { add_wishlist, delete_wishlist } from '../../utils/mutations';
 
 
 export const useWishlist = (refetch) => {

--- a/client/src/pages/Explore/Explore.jsx
+++ b/client/src/pages/Explore/Explore.jsx
@@ -65,7 +65,7 @@ export default function Explore() {
 
    // Grab wishlistedItems data (boolean)
    const wishlistedItems = wishlistData ? wishlistData.usersWishlist : [];
-   console.log('Wishlist Data:', wishlistedItems);
+  //  console.log('Wishlist Data:', wishlistedItems);
 
 
   return (

--- a/client/src/pages/Explore/Explore.jsx
+++ b/client/src/pages/Explore/Explore.jsx
@@ -12,12 +12,12 @@ export default function Explore() {
   const [selectedCategory, setSelectedCategory] = useState(''); // Manage state of selected Category
 
   // Load Products - pass refetch to child, so this query reruns when its added to wishlist/cart
-  const [loadProducts, {loading: loadingProducts, data: productsData, error: productsError, refetch: refetchProducts}] = useLazyQuery(Products, {
+  const [loadProducts, {loading: loadingProducts, data: productsData, error: productsError }] = useLazyQuery(Products, {
     variables: {category: selectedCategory}
   })
 
   // Load array of productIds (all items in users' wishlist)
-  const [loadWishlist, {loading: loadingWishlist, data: wishlistData, error: wishlistError}] = useLazyQuery(Wishlist, {
+  const [loadWishlist, {loading: loadingWishlist, data: wishlistData, error: wishlistError, refetch: refetchWishlist}] = useLazyQuery(Wishlist, {
     variables: {id: id}
   })
 
@@ -27,7 +27,7 @@ export default function Explore() {
   }, [loadProducts]); 
 
 
-    // Load Wishlist - Trigger when user changes
+  // Load Wishlist - Trigger when user changes
   useEffect(() => {
     if (user) {
       loadWishlist();
@@ -80,7 +80,7 @@ export default function Explore() {
        
         {/* Products */}
         <Grid item xs={12} marginTop={4}>
-          <ProductsMain products={products} wishlistedItems={wishlistedItems} refetchProducts={refetchProducts}/>
+          <ProductsMain products={products} wishlistedItems={wishlistedItems} refetchWishlist={refetchWishlist}/>
         </Grid>
 
 

--- a/client/src/pages/Explore/Explore.jsx
+++ b/client/src/pages/Explore/Explore.jsx
@@ -9,14 +9,14 @@ import { useAuthContext } from '../../hooks/useAuthContext';
 
 export default function Explore() {
   const { user, id } = useAuthContext()
-  const [selectedCategory, setSelectedCategory] = useState(''); // Manage state of selected Category
+  const [selectedCategory, setSelectedCategory] = useState(''); // state of selected Category
 
-  // Load Products - pass refetch to child, so this query reruns when its added to wishlist/cart
+  // Load Products  - filter loaded products by selected category
   const [loadProducts, {loading: loadingProducts, data: productsData, error: productsError }] = useLazyQuery(Products, {
     variables: {category: selectedCategory}
   })
 
-  // Load array of productIds (all items in users' wishlist)
+  // Load Wishlist - array of productIds (all items in users' wishlist). refetch whenever item is added/removed from wishlist
   const [loadWishlist, {loading: loadingWishlist, data: wishlistData, error: wishlistError, refetch: refetchWishlist}] = useLazyQuery(Wishlist, {
     variables: {id: id}
   })

--- a/client/src/pages/Explore/Product/ProductsMain.jsx
+++ b/client/src/pages/Explore/Product/ProductsMain.jsx
@@ -67,19 +67,19 @@ export default function ProductsMain({ products, wishlistedItems, refetchProduct
         setTimeout(() => {
           setErrorAlertVisible(false);
         }, 2500);
-        // refetchProducts(); // Refetch products after error
+        // refetchProducts(); 
       }
     } else {
       setWarningAlertVisible(true);
       setTimeout(() => {
         setWarningAlertVisible(false);
       }, 2500);
-      // refetchProducts(); // Refetch products after adding to wishlist
+      // refetchProducts(); 
       return;
     }
-    // Refetch products after adding to wishlist & updating states
-  refetchProducts();
+  refetchProducts();  // Refetch products after adding to wishlist & updating states
   };
+
 
   return (
     <Grid container spacing={3} marginBottom={6}>
@@ -88,7 +88,6 @@ export default function ProductsMain({ products, wishlistedItems, refetchProduct
     <WishlistWarning visible={warningAlertVisible} /> 
     <WishlistSuccess visible={successAlertVisible}/>
     <WishlistError visible={errorAlertVisible}/>
-
 
       {/* If no products in selected categor, render message, else map */}
       {!products || products.length === 0 ? (

--- a/client/src/pages/Explore/Product/ProductsMain.jsx
+++ b/client/src/pages/Explore/Product/ProductsMain.jsx
@@ -15,15 +15,15 @@ import WishlistWarning from '../../../components/Alerts/Wishlist/WishlistWarning
 import WishlistError from '../../../components/Alerts/Wishlist/WishlistError';
 
 
-export default function ProductsMain({ products, wishlistedItems, refetchProducts }) {
+export default function ProductsMain({ products, wishlistedItems, refetchWishlist }) {
   const { user, id } = useAuthContext();
   const [inWishlist , setInWishlist] = useState({}); // set to true if item in users wishlist
 
-  // loadWishlist - query the user by id
+  // Query loadWishlist - query the user by id
   const [loadWishlist, { loading, data, error, refetch }] = useLazyQuery(User, {
-    variables: { userId: id },});
+    variables: { userId: id }});
 
-  // Hook - add/remove wishlisted item
+  // Hook - add/remove wishlist item
   const { addWishlist, deleteWishlist, isLoading, stateError } = useWishlist(refetch);
 
   // Wishlist Alerts
@@ -31,13 +31,17 @@ export default function ProductsMain({ products, wishlistedItems, refetchProduct
   const [warningAlertVisible, setWarningAlertVisible] = useState(false);
   const [errorAlertVisible, setErrorAlertVisible] = useState(false);
 
-  // TODO: check users wishlist for items w iDs matching items iDs from product db
-  // => set the wishlist icon as active
+
+  // Load Wishlist - Trigger when user changes
   useEffect(() => {
-    loadWishlist();
+    if (user) {
+      loadWishlist();
+    }
   }, [loadWishlist, user]);
 
 
+  // if wishlistedItems is an array of Ids, for each Id, create an object that is truthy
+  // Run on initial render, and if wishlistedItems changes
   useEffect(() => {
     if (Array.isArray(wishlistedItems)) {
       const wishlistMap = {};
@@ -56,7 +60,6 @@ export default function ProductsMain({ products, wishlistedItems, refetchProduct
         await addWishlist(itemId, userId); // custom hook to add to wishlist
         setSuccessAlertVisible(true);
         setInWishlist((prev) => ({ ...prev, [itemId]: true }));
-        // refetchProducts(); // Refetch products after adding to wishlist
         setTimeout(() => {
           setSuccessAlertVisible(false);
         }, 2500);
@@ -67,17 +70,15 @@ export default function ProductsMain({ products, wishlistedItems, refetchProduct
         setTimeout(() => {
           setErrorAlertVisible(false);
         }, 2500);
-        // refetchProducts(); 
       }
     } else {
       setWarningAlertVisible(true);
       setTimeout(() => {
         setWarningAlertVisible(false);
       }, 2500);
-      // refetchProducts(); 
       return;
     }
-  refetchProducts();  // Refetch products after adding to wishlist & updating states
+    refetchWishlist();  // Refetch (loadWishlist()) after adding to wishlist & updating states
   };
 
 
@@ -109,7 +110,7 @@ export default function ProductsMain({ products, wishlistedItems, refetchProduct
         </Grid>
       ) : (
         <>
-          {/* Product Filters */}
+          {/* Product Filters - Price and Date */}
           <Grid item xs={12} marginY={1}>
             <ProductFilters />
           </Grid>
@@ -185,7 +186,7 @@ export default function ProductsMain({ products, wishlistedItems, refetchProduct
                           <Tooltip title='Add to wishlist' placement='right'>
                             <Checkbox
                               color='error'
-                              checked={inWishlist[result._id] || false} // Check if result._id exists in inWishlist array
+                              checked={inWishlist[result._id] || false} // Check if id exists in inWishlist array
                               onChange={() =>
                                 handleWishlistChange(id, result._id)}
                               icon={<FavoriteBorder />}

--- a/client/src/pages/Explore/Product/ProductsMain.jsx
+++ b/client/src/pages/Explore/Product/ProductsMain.jsx
@@ -8,8 +8,6 @@ import { useState, useEffect } from 'react';
 import ProductFilters from '../Filters/ProductFilters';
 import placeholder from '../../../assets/images/brand/no-products.svg';
 import AddToCart from '../../../components/Buttons/AddToCart';
-import { useLazyQuery } from '@apollo/client';
-import { User } from '../../../utils/queries';
 import WishlistSuccess from '../../../components/Alerts/Wishlist/WishlistSuccess';
 import WishlistWarning from '../../../components/Alerts/Wishlist/WishlistWarning';
 import WishlistError from '../../../components/Alerts/Wishlist/WishlistError';

--- a/client/src/pages/Explore/Product/ProductsMain.jsx
+++ b/client/src/pages/Explore/Product/ProductsMain.jsx
@@ -19,26 +19,13 @@ export default function ProductsMain({ products, wishlistedItems, refetchWishlis
   const { user, id } = useAuthContext();
   const [inWishlist , setInWishlist] = useState({}); // set to true if item in users wishlist
 
-  // Query loadWishlist - query the user by id
-  const [loadWishlist, { loading, data, error, refetch }] = useLazyQuery(User, {
-    variables: { userId: id }});
-
   // Hook - add/remove wishlist item
-  const { addWishlist, deleteWishlist, isLoading, stateError } = useWishlist(refetch);
+  const { addWishlist, deleteWishlist, isLoading, stateError } = useWishlist();
 
   // Wishlist Alerts
   const [successAlertVisible, setSuccessAlertVisible] = useState(false);
   const [warningAlertVisible, setWarningAlertVisible] = useState(false);
   const [errorAlertVisible, setErrorAlertVisible] = useState(false);
-
-
-  // Load Wishlist - Trigger when user changes
-  useEffect(() => {
-    if (user) {
-      loadWishlist();
-    }
-  }, [loadWishlist, user]);
-
 
   // if wishlistedItems is an array of Ids, for each Id, create an object that is truthy
   // Run on initial render, and if wishlistedItems changes
@@ -53,7 +40,7 @@ export default function ProductsMain({ products, wishlistedItems, refetchWishlis
   }, [wishlistedItems]);
   
 
-  // OnChange - handle wishlist
+  // OnChange - Refetch (loadWishlist()) from parent updating items wishlist state
   const handleWishlistChange = async (userId, itemId) => {
     if (user) {
       try {
@@ -78,7 +65,7 @@ export default function ProductsMain({ products, wishlistedItems, refetchWishlis
       }, 2500);
       return;
     }
-    refetchWishlist();  // Refetch (loadWishlist()) after adding to wishlist & updating states
+    refetchWishlist();  
   };
 
 

--- a/client/src/pages/Navbar/Drawers/MenuDrawer.jsx
+++ b/client/src/pages/Navbar/Drawers/MenuDrawer.jsx
@@ -52,13 +52,13 @@ export default function MenuDrawer() {
         {user && type === 'vendor' ? (
           null
         ) : user && type === 'buyer' ? (
-          <ListItem key='Home' disablePadding>
+          <ListItem key='Shop' disablePadding>
             <ListItemButton onClick={closeDrawer}>
               <NavLink
                 to='/explore'
                 style={{ textDecoration: 'none', color: 'inherit' }}
               >
-                <ListItemText primary='Home' />
+                <ListItemText primary='Shop' />
               </NavLink>
             </ListItemButton>
           </ListItem>

--- a/client/src/pages/Navbar/Navigation/TopNavbar.jsx
+++ b/client/src/pages/Navbar/Navigation/TopNavbar.jsx
@@ -21,12 +21,12 @@ export default function MainNav() {
         {user && type ==='vendor' ? (
           null
         ) : user && type==='buyer' ? (
-        <Button key='Home' sx={{ color: '#fff', textTransform: 'none' }}>
+        <Button key='Shop' sx={{ color: '#fff', textTransform: 'none' }}>
             <NavLink
               to='/explore'
               style={{ textDecoration: 'none', color: 'inherit' }}
             >
-              Home
+              Shop
             </NavLink>
         </Button>
         ) : (

--- a/client/src/pages/Profile/Buyer/BottomNav.jsx
+++ b/client/src/pages/Profile/Buyer/BottomNav.jsx
@@ -6,6 +6,7 @@ import MailIcon from '@mui/icons-material/Mail';
 import Paper from '@mui/material/Paper';
 import AccountBoxIcon from '@mui/icons-material/AccountBox';
 import HomeIcon from '@mui/icons-material/Home';
+import StoreIcon from '@mui/icons-material/Store';
 import { NavLink } from 'react-router-dom';
 import { useAuthContext } from '../../../hooks/useAuthContext';
 import InsightsIcon from '@mui/icons-material/Insights';
@@ -42,8 +43,8 @@ export default function BottomNav() {
           <BottomNavigationAction
             component={NavLink}
             to='/explore'
-            label='Home'
-            icon={<HomeIcon />}
+            label='Shop'
+            icon={<StoreIcon />}
             showLabel
           />
           )}

--- a/client/src/pages/Profile/Buyer/Profile/Accordion/AccordionMain.jsx
+++ b/client/src/pages/Profile/Buyer/Profile/Accordion/AccordionMain.jsx
@@ -17,30 +17,14 @@ import ReviewsImgList from './ReviewsImgList';
 
 
 
-export default function ProfileAccordion() {
+export default function ProfileAccordion( {refetchUserData, loadUser, userData} ) {
   const { id, type } = useAuthContext()
-  const [loadUser, { loading, data, error }] = useLazyQuery(User, {
-    variables: { userId: id },
-  });
-
+ 
   // Run loadUser 1x when component renders - re-run loadUser if it changes
   useEffect(() => {
-    loadUser();
+    refetchUserData();
   }, [loadUser]);
 
-  if (error) {
-    console.error('GraphQL Error:', error);
-    return <p>Error fetching data</p>;
-  }
-  if (loading) {
-    return <p>Loading...</p>; // Replace with loading spinner
-  }
-  if (!data || !data.user) {
-    return <p>No user data found</p>;
-  }
-
-  // Grab data
-  const user = data.user;
 
   return (
     <Box sx={{ marginBottom: { xs: 8, md: 0 } }}>
@@ -55,7 +39,7 @@ export default function ProfileAccordion() {
           <Typography>Wishlist</Typography>
         </AccordionSummary>
         <AccordionDetails>
-          {user.wishlist.length > 0 ? (
+          {userData.wishlist.length > 0 ? (
             <Typography variant='caption'>
               <WishImglist />
             </Typography>
@@ -80,7 +64,7 @@ export default function ProfileAccordion() {
           <Typography>Cart</Typography>
         </AccordionSummary>
         <AccordionDetails>
-          {user.cart.length > 0 ? (
+          {userData.cart.length > 0 ? (
             <Typography variant='caption'>
               <CartImgList />
             </Typography>
@@ -105,7 +89,7 @@ export default function ProfileAccordion() {
           <Typography>Order History</Typography>
         </AccordionSummary>
         <AccordionDetails>
-          {user.buyHistory.length > 0 ? (
+          {userData.buyHistory.length > 0 ? (
             <Typography variant='caption'>
               <OrdersImgList />
             </Typography>
@@ -130,7 +114,7 @@ export default function ProfileAccordion() {
           <Typography>Reviews</Typography>
         </AccordionSummary>
         <AccordionDetails>
-          {user.ratings.length > 0 ? (
+          {userData.ratings.length > 0 ? (
             <Typography variant='caption'>
               <ReviewsImgList />
             </Typography>
@@ -156,9 +140,9 @@ export default function ProfileAccordion() {
             <List>
               <ListItem>Account Type: {type}</ListItem>
               <ListItem>
-                Name: {user.firstName} {user.lastName}
+                Name: {userData.firstName} {userData.lastName}
               </ListItem>
-              <ListItem>Email Address: {user.email}</ListItem>
+              <ListItem>Email Address: {userData.email}</ListItem>
               {/* <ListItem>Created on: TBD </ListItem> */}
             </List>
           </Typography>

--- a/client/src/pages/Profile/Buyer/Profile/Accordion/AccordionMain.jsx
+++ b/client/src/pages/Profile/Buyer/Profile/Accordion/AccordionMain.jsx
@@ -41,7 +41,9 @@ export default function ProfileAccordion( {refetchUserData, loadUser, userData} 
         <AccordionDetails>
           {userData.wishlist.length > 0 ? (
             <Typography variant='caption'>
-              <WishImglist />
+
+              <WishImglist refetchUserData={refetchUserData} loadUser={loadUser} userData={userData} />
+
             </Typography>
           ) : (
             <Typography variant='caption'>
@@ -66,7 +68,9 @@ export default function ProfileAccordion( {refetchUserData, loadUser, userData} 
         <AccordionDetails>
           {userData.cart.length > 0 ? (
             <Typography variant='caption'>
-              <CartImgList />
+
+              <CartImgList refetchUserData={refetchUserData} loadUser={loadUser} userData={userData} />
+
             </Typography>
           ) : (
             <Typography variant='caption'>
@@ -91,7 +95,9 @@ export default function ProfileAccordion( {refetchUserData, loadUser, userData} 
         <AccordionDetails>
           {userData.buyHistory.length > 0 ? (
             <Typography variant='caption'>
-              <OrdersImgList />
+
+              <OrdersImgList refetchUserData={refetchUserData} loadUser={loadUser} userData={userData} />
+
             </Typography>
           ) : (
             <Typography variant='caption'>
@@ -116,7 +122,9 @@ export default function ProfileAccordion( {refetchUserData, loadUser, userData} 
         <AccordionDetails>
           {userData.ratings.length > 0 ? (
             <Typography variant='caption'>
-              <ReviewsImgList />
+
+              <ReviewsImgList refetchUserData={refetchUserData} loadUser={loadUser} userData={userData} />
+
             </Typography>
           ) : (
             <Typography variant='caption'>

--- a/client/src/pages/Profile/Buyer/Profile/Accordion/CartImgList.jsx
+++ b/client/src/pages/Profile/Buyer/Profile/Accordion/CartImgList.jsx
@@ -1,43 +1,9 @@
-import ImageList from '@mui/material/ImageList';
-import ImageListItem from '@mui/material/ImageListItem';
-import ImageListItemBar from '@mui/material/ImageListItemBar';
-import ListSubheader from '@mui/material/ListSubheader';
-import IconButton from '@mui/material/IconButton';
+import {ImageList, ImageListItem, ImageListItemBar, ListSubheader, IconButton} from '@mui/material';
 import InfoIcon from '@mui/icons-material/Info';
-import { useEffect } from 'react';
-import { useLazyQuery } from '@apollo/client';
-import { User } from '../../../../../utils/queries';
-import { useAuthContext } from '../../../../../hooks/useAuthContext';
 
 
-export default function CartImgList() {
-  const { id } = useAuthContext()
-  const [loadUser, { loading, data, error }] = useLazyQuery(User, {
-    variables: { userId: id },
-  });
-
-  // Run loadUser 1x when component renders - re-run loadUser if it changes
-  useEffect(() => {
-    loadUser();
-  }, [loadUser]);
-
-  if (error) {
-    console.error('GraphQL Error:', error);
-    return <p>Error fetching data</p>;
-  }
-  if (loading) {
-    return <p>Loading...</p>; // Replace with loading spinner
-  }
-  if (!data || !data.user) {
-    return <p>No user data found</p>;
-  }
-
-  // Grab data
-  const user = data.user;
-  // console.log('User Cart: ', user.cart)
-
-  // Calculate cart subtotal
-  const subtotal = user.cart.reduce((total, item) => {
+export default function CartImgList({ refetchUserData, loadUser, userData  }) {
+  const subtotal = userData.cart.reduce((total, item) => { // Calculate cart subtotal
     return total + item.item.price;
   }, 0);
   
@@ -47,7 +13,7 @@ export default function CartImgList() {
       <ImageListItem key='Subheader' cols={2}>
         <ListSubheader component='div'>Subtotal: ${subtotal} </ListSubheader>
       </ImageListItem>
-      {user.cart.map((item, index) => (
+      {userData.cart.map((item, index) => (
         <ImageListItem key={index}>
           <img
             srcSet={item.item.img}

--- a/client/src/pages/Profile/Buyer/Profile/Accordion/OrdersImgList.jsx
+++ b/client/src/pages/Profile/Buyer/Profile/Accordion/OrdersImgList.jsx
@@ -1,47 +1,15 @@
-import ImageList from '@mui/material/ImageList';
-import ImageListItem from '@mui/material/ImageListItem';
-import ImageListItemBar from '@mui/material/ImageListItemBar';
-import ListSubheader from '@mui/material/ListSubheader';
-import IconButton from '@mui/material/IconButton';
+import {ImageList, ImageListItem, ImageListItemBar, ListSubheader, IconButton} from '@mui/material';
 import InfoIcon from '@mui/icons-material/Info';
-import { useEffect } from 'react';
-import { useLazyQuery } from '@apollo/client';
-import { User } from '../../../../../utils/queries';
-import { useAuthContext } from '../../../../../hooks/useAuthContext';
 
 
-export default function OrdersImgList() {
-  const { id } = useAuthContext()
-  const [loadUser, { loading, data, error }] = useLazyQuery(User, {
-    variables: { userId: id },
-  });
-
-  // Run loadUser 1x when component renders - re-run loadUser if it changes
-  useEffect(() => {
-    loadUser();
-  }, [loadUser]);
-
-  if (error) {
-    console.error('GraphQL Error:', error);
-    return <p>Error fetching data</p>;
-  }
-  if (loading) {
-    return <p>Loading...</p>; // Replace with loading spinner
-  }
-  if (!data || !data.user) {
-    return <p>No user data found</p>;
-  }
-
-  // Grab data
-  const user = data.user;
-  // console.log('User Order history: ', user.buyHistory)
+export default function OrdersImgList({ refetchUserData, loadUser, userData }) {
 
   return (
     <ImageList>
       <ImageListItem key='Subheader' cols={2}>
         <ListSubheader component='div'>Orders</ListSubheader>
       </ImageListItem>
-      {user.buyHistory.map((item, index) => (
+      {userData.buyHistory.map((item, index) => (
         <ImageListItem key={index}>
           <img
             srcSet={item.item.img}

--- a/client/src/pages/Profile/Buyer/Profile/Accordion/ReviewsImgList.jsx
+++ b/client/src/pages/Profile/Buyer/Profile/Accordion/ReviewsImgList.jsx
@@ -1,37 +1,12 @@
 import { useState } from 'react';
-import Box from '@mui/material/Box';
-import Button from '@mui/material/Button';
-import Typography from '@mui/material/Typography';
-import Modal from '@mui/material/Modal';
-import ImageList from '@mui/material/ImageList';
-import ImageListItem from '@mui/material/ImageListItem';
-import ImageListItemBar from '@mui/material/ImageListItemBar';
-import ListSubheader from '@mui/material/ListSubheader';
-import IconButton from '@mui/material/IconButton';
+import {Box, Button, IconButton, Typography, Modal, Rating} from '@mui/material';
+import {ImageList, ImageListItem, ImageListItemBar, ListSubheader} from '@mui/material';
 import InfoIcon from '@mui/icons-material/Info';
-import { useEffect } from 'react';
-import { useLazyQuery } from '@apollo/client';
-import { User } from '../../../../../utils/queries';
-import { useAuthContext } from '../../../../../hooks/useAuthContext';
-import { Rating } from '@mui/material';
 
-const style = {
-  position: 'absolute',
-  top: '50%',
-  left: '50%',
-  transform: 'translate(-50%, -50%)',
-  width: 400,
-  bgcolor: 'background.paper',
-  border: '1px solid #000',
-  boxShadow: 24,
-  p: 4,
-  textAlign: 'center',
-};
 
-// Modal for each Review
-export default function ReviewsImgList() {
-  const { id } = useAuthContext()
+export default function ReviewsImgList({ refetchUserData, loadUser, userData }) {
   const [openModals, setOpenModals] = useState([]);
+
 
   const handleOpenModal = (index) => {
     const newOpenModals = [...openModals];
@@ -45,37 +20,13 @@ export default function ReviewsImgList() {
     setOpenModals(newOpenModals);
   };
 
-  const [loadUser, { loading, data, error }] = useLazyQuery(User, {
-    variables: { userId: id },
-  });
-
-  // Run loadUser 1x when component renders - re-run loadUser if it changes
-  useEffect(() => {
-    loadUser();
-  }, [loadUser]);
-
-  if (error) {
-    console.error('GraphQL Error:', error);
-    return <p>Error fetching data</p>;
-  }
-  if (loading) {
-    return <p>Loading...</p>; // Replace with loading spinner
-  }
-  if (!data || !data.user) {
-    return <p>No user data found</p>;
-  }
-
-  // Grab data
-  const user = data.user;
-  // console.log('Users item reviews: ', user.ratings )
-
   return (
     <Box>
       <ImageList>
         <ImageListItem key='Subheader' cols={2}>
           <ListSubheader component='div'>Reviewed Items</ListSubheader>
         </ImageListItem>
-        {user.ratings.map((rating, index) => (
+        {userData.ratings.map((rating, index) => (
           <ImageListItem key={index}>
             <Button onClick={() => handleOpenModal(index)}>
               <img
@@ -98,13 +49,25 @@ export default function ReviewsImgList() {
                 </IconButton>
               }
             />
+
+            {/* Modal for each Review */}
             <Modal
               open={openModals[index] || false}
               onClose={() => handleCloseModal(index)}
               aria-labelledby='modal-modal-title'
               aria-describedby='modal-modal-description'
             >
-              <Box sx={style}>
+              <Box sx={{position: 'absolute',
+                top: '50%',
+                left: '50%',
+                transform: 'translate(-50%, -50%)',
+                width: 400,
+                bgcolor: 'background.paper',
+                border: '1px solid #000',
+                boxShadow: 24,
+                p: 4,
+                textAlign: 'center'
+                }}>
                 <img
                   srcSet={rating.item.img}
                   src={rating.item.img}

--- a/client/src/pages/Profile/Buyer/Profile/Accordion/WishlistImgList.jsx
+++ b/client/src/pages/Profile/Buyer/Profile/Accordion/WishlistImgList.jsx
@@ -21,6 +21,7 @@ export default function WishImglist() {
   const [loadUser, { loading, data, error, refetch }] = useLazyQuery(User, {
     variables: { userId: id },
   });
+  
   const { deleteWishlist, isLoading, stateError } = useWishlist(refetch);
 
   // Run loadUser when component renders - re-run if loadUser changes

--- a/client/src/pages/Profile/Buyer/Profile/Accordion/WishlistImgList.jsx
+++ b/client/src/pages/Profile/Buyer/Profile/Accordion/WishlistImgList.jsx
@@ -13,7 +13,7 @@ import { User } from '../../../../../utils/queries';
 import { useWishlist } from '../../../../../hooks/Products/useWishlist';
 import { useAuthContext } from '../../../../../hooks/useAuthContext';
 
-export default function WishImglist() {
+export default function WishImglist () {
   const { id } = useAuthContext();
   const [openModals, setOpenModals] = useState([]);
   const [alert, setAlert] = useState({});

--- a/client/src/pages/Profile/Buyer/Profile/Accordion/WishlistImgList.jsx
+++ b/client/src/pages/Profile/Buyer/Profile/Accordion/WishlistImgList.jsx
@@ -1,33 +1,18 @@
 import { useState } from 'react';
 import { Box, Stack, Button, Typography, Modal, Alert } from '@mui/material';
-import {
-  ImageList,
-  ImageListItem,
-  ImageListItemBar,
-  IconButton,
-} from '@mui/material';
+import { ImageList, ImageListItem, ImageListItemBar, IconButton } from '@mui/material';
 import InfoIcon from '@mui/icons-material/Info';
-import { useEffect } from 'react';
-import { useLazyQuery } from '@apollo/client';
-import { User } from '../../../../../utils/queries';
 import { useWishlist } from '../../../../../hooks/Products/useWishlist';
 import { useAuthContext } from '../../../../../hooks/useAuthContext';
 
-export default function WishImglist () {
+
+export default function WishImglist ({ refetchUserData, userData }) {
   const { id } = useAuthContext();
   const [openModals, setOpenModals] = useState([]);
   const [alert, setAlert] = useState({});
   const [showButton, setShowButton] = useState({});
-  const [loadUser, { loading, data, error, refetch }] = useLazyQuery(User, {
-    variables: { userId: id },
-  });
   
-  const { deleteWishlist, isLoading, stateError } = useWishlist(refetch);
-
-  // Run loadUser when component renders - re-run if loadUser changes
-  useEffect(() => {
-    loadUser();
-  }, [alert]);
+  const { deleteWishlist, isLoading, stateError } = useWishlist(refetchUserData);
 
   const handleOpenModal = (index) => {
     const newOpenModals = [...openModals];
@@ -45,8 +30,6 @@ export default function WishImglist () {
   const removeFromWishlist = async (userId, itemId, index) => {
     try {
       await deleteWishlist(itemId, userId);
-      // console.log(`Item ${itemId} removed from User ${userId}s wishlist`);
-
       setShowButton((prev) => ({ ...prev, [itemId]: false }));
       setAlert((prev) => ({ ...prev, [itemId]: true }));
       setTimeout(() => {
@@ -58,25 +41,11 @@ export default function WishImglist () {
     }
   };
 
-  if (error) {
-    console.error('GraphQL Error:', error);
-    return <p>Error fetching data</p>;
-  }
-  if (loading) {
-    return <p>Loading...</p>; // Replace with loading spinner
-  }
-  if (!data || !data.user) {
-    return <p>No user data found</p>;
-  }
-
-  // Grab data
-  const user = data.user;
-  // console.log('Users wishlist: ', user.wishlist );
 
   return (
     <Box>
       <ImageList>
-        {user.wishlist.map((item, index) => (
+        {userData.wishlist.map((item, index) => (
           <ImageListItem key={index}>
             <Button onClick={() => handleOpenModal(index)}>
               <img

--- a/client/src/pages/Profile/Buyer/Profile/BuyerProfile.jsx
+++ b/client/src/pages/Profile/Buyer/Profile/BuyerProfile.jsx
@@ -13,8 +13,6 @@ export default function BuyerProfile() {
   const [loadUser, { loading, data, error, refetch: refetchUserData }] = useLazyQuery(User, {
     variables: { userId: id },});
 
-
-    
   useEffect(() => {
     // Call loadUser only if user is truthy
     if (user) {
@@ -31,6 +29,7 @@ export default function BuyerProfile() {
   if (!data || !data.user) {
     return <p>No user data found</p>;
   }
+
 
   // User data object
   const userData = data.user;

--- a/client/src/pages/Profile/Buyer/Profile/BuyerProfile.jsx
+++ b/client/src/pages/Profile/Buyer/Profile/BuyerProfile.jsx
@@ -10,10 +10,11 @@ import { useAuthContext } from '../../../../hooks/useAuthContext';
 
 export default function BuyerProfile() {
   const { user, id } = useAuthContext()
-  const [loadUser, { loading, data, error }] = useLazyQuery(User, {
+  const [loadUser, { loading, data, error, refetch: refetchUserData }] = useLazyQuery(User, {
     variables: { userId: id },});
 
-  // Auth check 
+
+    
   useEffect(() => {
     // Call loadUser only if user is truthy
     if (user) {
@@ -83,7 +84,7 @@ export default function BuyerProfile() {
 
           {/* ACCORDIONS - component  */}
           <Grid item>
-            <ProfileAccordions />
+            <ProfileAccordions refetchUserData={refetchUserData} loadUser={loadUser} userData={userData} />
           </Grid>
 
         </Grid>

--- a/client/src/utils/queries.js
+++ b/client/src/utils/queries.js
@@ -56,6 +56,14 @@ export const User = gql`
   }
 `;
 
+// Wishlist - returns array of product IDs in users wishlist
+export const Wishlist = gql`
+  query UserWishlist($id: ID!) {
+    usersWishlist(id: $id)
+  }
+`;
+
+
 ////////////////////////////////////////
 
 
@@ -124,9 +132,4 @@ query SingleProductQuery($id: ID!) {
   }
 }
 `
-// Wishlist - returns array of product IDs in users wishlist
-export const Wishlist = gql`
-  query UserWishlist($id: ID!) {
-    usersWishlist(id: $id)
-  }
-`;
+


### PR DESCRIPTION
- Wishlist now being refetched as targeted, so wishlisted items persist explore page. Moved refetch from loadProducts to loadWishlist
- Refactored Buyer profile component tree to utilize props and pass from parent as needed, instead of running the same query for the same data, the same useEffect, etc, on each child component.
- Disabled es lint rules: no-unused-vars rule & prop-types rule.
- fixed off centered and extended width issue on Wishlist alerts. Adjusted cart alerts to match styling
- updated buyer side usage of home to shop instead